### PR TITLE
dropzone bugs

### DIFF
--- a/public/assets/css/fields.css
+++ b/public/assets/css/fields.css
@@ -29,6 +29,12 @@ form.dropzone {
             align-items: center;
             margin: 0 auto;
         }
+        .dz-size {
+            display: none;
+        }
+        .dz-filename {
+            margin-top: 25px;
+        }
         .dz-remove {
             margin: 0 auto;
         }

--- a/resources/views/admin/events/index.blade.php
+++ b/resources/views/admin/events/index.blade.php
@@ -58,7 +58,7 @@
         </x-admin.datatable>
 
         <div class="sliders">
-            <x-forms.input-dropzone attribute="gallery" :model="$gallery" id="homeGallery" label="Gallerij"/>
+            <x-forms.input-dropzone attribute="gallery" :model="$gallery" id="homeGallery" label="Home gallerij"/>
         </div>
     </div>
 @endsection

--- a/resources/views/admin/galleries/index.blade.php
+++ b/resources/views/admin/galleries/index.blade.php
@@ -7,7 +7,7 @@
         <x-forms.input-dropzone attribute="gallery"
                                 :model="$gallery"
                                 id="homeGallery"
-                                label="Gallerij"
+                                label="Gallerij pagina"
                                 :metadatas="[
                                                 ['type' => 'text', 'name' => 'event_name', 'label' => 'Evenement'],
                                                 ['type' => 'date', 'name' => 'event_date', 'label' => 'Datum']

--- a/resources/views/components/forms/input-dropzone.blade.php
+++ b/resources/views/components/forms/input-dropzone.blade.php
@@ -11,7 +11,9 @@
     <label class="block text-gray-700 text-sm font-bold mb-1" for="{{ $id }}">
         {{ ucfirst($label) }}
     </label>
-    <h5 id="message" class="text-center text-danger"></h5>
+    <h5 id="message" class="">
+        Sleep bestanden hierheen of klik om te uploaden
+    </h5>
 
     <form action="{{ isset($model) ? route( 'admin.gallery.upload',  [strtolower(class_basename($model)), $model->id]) : route('admin.gallery.store', $modelname) }}" method="POST" enctype="multipart/form-data" class="dropzone border border-gray-400 bg-white rounded-md w-full py-2 px-3 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 hover:border-gray-500 {{ $class }}" id="{{$id}}">
         @csrf
@@ -93,7 +95,7 @@
     function createEditButton(fileName, metadataValues, container) {
         var editButton = document.createElement('button');
         editButton.className = 'dz-metadata-button dz-edit-button';
-        editButton.innerHTML = 'Bewerk Metadata';
+        editButton.innerHTML = 'Bewerk data';
         editButton.type = 'button';
         editButton.onclick = function(e) {
             e.preventDefault();
@@ -190,7 +192,7 @@
             acceptedFiles: ".jpeg,.jpg,.png,.webp,.gif,.svg",
             addRemoveLinks: {{ isset($model) }},
             timeout: 60000,
-            dictDefaultMessage: "Sleep bestanden hierheen of klik om te uploaden",
+            dictDefaultMessage: "",
             dictFileTooBig: "Bestand is te groot (max. "+maxFilesize+" MB)",
             dictInvalidFileType: "Bestandstype ongeldig. Alleen JPG, JPEG, PNG, WEBP, GIF, SVG zijn toegestaan.",
             dictRemoveFile: "Verwijder bestand",

--- a/resources/views/components/forms/input-dropzone.blade.php
+++ b/resources/views/components/forms/input-dropzone.blade.php
@@ -8,10 +8,10 @@
     'metadatas' => [],
    ])
 <div class="mb-4">
-    <label class="block text-gray-700 text-sm font-bold mb-1" for="{{ $id }}">
+    <label class="block text-gray-700 font-bold mb-1" for="{{ $id }}">
         {{ ucfirst($label) }}
     </label>
-    <h5 id="message" class="">
+    <h5 id="message" class="text-sm text-gray-700 font-bold mb-1">
         Sleep bestanden hierheen of klik om te uploaden
     </h5>
 


### PR DESCRIPTION
-	Voor alle galerijen duidelijk neerzetten welke het is, aangezien er meerdere verschillende galerijen zijn op de website (naamgeving en evt infotekstje)
-	De grootte van een bestand hoeft niet zichtbaar te zijn bij het hoveren over een foto op de adminkant.
-	Het duidelijk maken hoe je foto’s toe kan voegen aan de galerij, al helemaal als er al foto’s instaan. Dit is op het moment echt niet duidelijk

glhf :)