### PR TITLE
image and accessibility fixes

### DIFF
--- a/app/Http/Requests/BoardMemberRequest.php
+++ b/app/Http/Requests/BoardMemberRequest.php
@@ -25,8 +25,8 @@ class BoardMemberRequest extends FormRequest
         return [
             'name' => 'required|max:255|string',
             'role' => 'required|max:255|string',
-            'description' => 'nullable|max:65535|'
-
+            'description' => 'nullable|max:65535|',
+            'image' => 'image|mimes:jpeg,png,jpg,webp|max:2048',
         ];
     }
 
@@ -35,8 +35,10 @@ class BoardMemberRequest extends FormRequest
         return [
             'name.required' => 'De naam is verplicht.',
             'role.required' => 'De rol is verplicht.',
-            'description.max' => 'De beschrijving mag niet langer zijn dan 65535 tekens.'
-
+            'description.max' => 'De beschrijving mag niet langer zijn dan 65535 tekens.',
+            'image.image' => 'Het gekozen bestand moet een afbeelding zijn.',
+            'image.mimes' => 'Alleen jpeg, jpg, png en webp bestanden zijn toegestaan.',
+            'image.max' => 'De afbeelding mag niet groter zijn dan 2MB.',
         ];
     }
 }

--- a/app/Http/Requests/BoardMemberRequest.php
+++ b/app/Http/Requests/BoardMemberRequest.php
@@ -26,7 +26,7 @@ class BoardMemberRequest extends FormRequest
             'name' => 'required|max:255|string',
             'role' => 'required|max:255|string',
             'description' => 'nullable|max:65535|',
-            'image' => 'image|mimes:jpeg,png,jpg,webp|max:2048',
+            'image' => 'image|mimes:jpeg,png,jpg,webp,svg|max:2048',
         ];
     }
 
@@ -37,7 +37,7 @@ class BoardMemberRequest extends FormRequest
             'role.required' => 'De rol is verplicht.',
             'description.max' => 'De beschrijving mag niet langer zijn dan 65535 tekens.',
             'image.image' => 'Het gekozen bestand moet een afbeelding zijn.',
-            'image.mimes' => 'Alleen jpeg, jpg, png en webp bestanden zijn toegestaan.',
+            'image.mimes' => 'Alleen jpeg, jpg, png, svg en webp bestanden zijn toegestaan.',
             'image.max' => 'De afbeelding mag niet groter zijn dan 2MB.',
         ];
     }

--- a/app/Http/Requests/OldBoardsRequest.php
+++ b/app/Http/Requests/OldBoardsRequest.php
@@ -26,6 +26,7 @@ class OldBoardsRequest extends FormRequest
         return [
             'names' => 'required|max:1000|string',
             'term' => ['required', new TermRange],
+            'image' => 'image|mimes:jpeg,png,jpg,webp|max:2048',
         ];
     }
 
@@ -33,6 +34,10 @@ class OldBoardsRequest extends FormRequest
     {
         return [
             'name.required' => 'De naam is verplicht.',
+            'image.required' => 'Een foto is verplicht.',
+            'image.image' => 'Het gekozen bestand moet een afbeelding zijn.',
+            'image.mimes' => 'Alleen jpeg, jpg, png en webp bestanden zijn toegestaan.',
+            'image.max' => 'De afbeelding mag niet groter zijn dan 2MB.',
         ];
     }
 }

--- a/app/Http/Requests/OldBoardsRequest.php
+++ b/app/Http/Requests/OldBoardsRequest.php
@@ -26,7 +26,7 @@ class OldBoardsRequest extends FormRequest
         return [
             'names' => 'required|max:1000|string',
             'term' => ['required', new TermRange],
-            'image' => 'image|mimes:jpeg,png,jpg,webp|max:2048',
+            'image' => 'image|mimes:jpeg,png,jpg,webp,svg|max:2048',
         ];
     }
 
@@ -36,7 +36,7 @@ class OldBoardsRequest extends FormRequest
             'name.required' => 'De naam is verplicht.',
             'image.required' => 'Een foto is verplicht.',
             'image.image' => 'Het gekozen bestand moet een afbeelding zijn.',
-            'image.mimes' => 'Alleen jpeg, jpg, png en webp bestanden zijn toegestaan.',
+            'image.mimes' => 'Alleen jpeg, jpg, png, svg en webp bestanden zijn toegestaan.',
             'image.max' => 'De afbeelding mag niet groter zijn dan 2MB.',
         ];
     }

--- a/public/assets/css/aboutUs.css
+++ b/public/assets/css/aboutUs.css
@@ -32,6 +32,10 @@
 
 
     }
+    .about-us-list{
+        list-style-type: decimal;
+        padding-left: 1rem;
+    }
 }
 
 @media (max-width: 768px) {

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="nl">
   <head>
     <link rel="icon" href="{{ asset('assets/images/favicon.ico') }}">
 

--- a/resources/views/user/about_us/index.blade.php
+++ b/resources/views/user/about_us/index.blade.php
@@ -14,11 +14,11 @@
                         Voorbeeldzinnen:
                     </p>
                     <br />
-                    <p>
-                        1. “Ik ben een informaticastudent, zit op school en ben opzoek naar gezelligheid, dus dan ga ik naar studievereniging Concat.”<br />
-                        2. Een bedrijf heeft een tekort aan informatica studenten, als oplossing benaderen ze studievereniging Concat.<br />
-                        3. SELECT CONCAT(SO, BIM) AS Gezelligheid FROM Avans;<br />
-                    </p>
+                    <ol class="about-us-list">
+                        <li>"Ik ben een informaticastudent, zit op school en ben op zoek naar gezelligheid, dus dan ga ik naar studievereniging Concat."</li>
+                        <li>Een bedrijf heeft een tekort aan informaticastudenten. Als oplossing benaderen ze studievereniging Concat.</li>
+                        <li>SELECT CONCAT(SO, BIM) AS Gezelligheid FROM Avans;</li>
+                    </ol>
                     <br />
                     <p>
                         Studievereniging Concat heeft twee hoofddoelen: studenten verbinden en een extensie zijn van de opleiding. Studenten verbinden met elkaar, docenten en het bedrijfsleven. Op deze manier willen wij studenten helpen om een gezellige studietijd te hebben en na de studietijd helemaal voorbereid te zijn voor het bedrijfsleven.


### PR DESCRIPTION
- de upload file inputs die bij de about-us horen accepteren nu alleen nog image files (bestuursleden en besturen)

ik heb ook de vrijheid genomen om de 'lijst' in de concat beschrijving als lijst te stylen, om aan de accessibility te voldoen (naar aanleiding van die feedback) 